### PR TITLE
Fix shell=True calls to Popen and split with shlex

### DIFF
--- a/lib/active/corescanner.py
+++ b/lib/active/corescanner.py
@@ -1,6 +1,7 @@
 
 try:
 	import os		
+	import shlex
 	import time
 	import datetime
 	import subprocess
@@ -34,7 +35,8 @@ class CoreScanner(object):
 		
 		logger._logging("START: Nmap {0}".format(self.__scan_type))
 		logger._logging("CMD - {0} : {1}".format(self.__scan_type, cmd))
-		
-		proc = subprocess.Popen([cmd], shell=True, stdout = subprocess.PIPE, stderr = subprocess.PIPE,).communicate()
+
+		cmd_list = shlex.split(cmd)
+		proc = subprocess.Popen(cmd_list, stdout = subprocess.PIPE, stderr = subprocess.PIPE,).communicate()
 
 		logger._logging("STOP: Nmap {0}".format(self.__scan_type))

--- a/lib/active/pingscan.py
+++ b/lib/active/pingscan.py
@@ -1,6 +1,7 @@
 
 try:
 	import re
+	import shlex
 	import datetime
 	import tempfile
 	import subprocess
@@ -35,7 +36,8 @@ class PingScan(CoreScanner):
 		logger._logging("START: Nmap Ping Scan")
 		logger._logging("CMD - Ping Scan: {0}".format(cmd))
 
-		proc = subprocess.Popen([cmd], shell=True, stdout=subprocess.PIPE,).communicate()
+		cmd_list = shlex.split(cmd)
+		proc = subprocess.Popen(cmd_list, stdout=subprocess.PIPE,).communicate()
 		try:
 			with open(gnmap_file, "r") as fd:
 				result_file.write("\n".join([ re.search(self.__host_up, line).groups()[0] for line in fd  if re.search(self.__host_up, line) ]))

--- a/lib/filterscan.py
+++ b/lib/filterscan.py
@@ -1,6 +1,7 @@
 try:
 	import os
 	import subprocess
+	import shlex
 	from lib.core.core import Core
 	from lib.filter.filter import Filter
 except ImportError, err:
@@ -24,7 +25,8 @@ class FilterScan(Filter):
                 logger._logging("Filter: {0} parsing".format(file_name))
                 logger._logging("CMD - Filter: {0}".format(cmd))
 
-                proc = subprocess.Popen([cmd], shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,)
+                cmd_list = shlex.split(cmd)
+                proc = subprocess.Popen(cmd_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE,)
                 if isinstance(result_set, (list, tuple)):
                         [ result_set.append(line) for line in iter(proc.stdout.readline, '') if line not in result_set ]
                 else:

--- a/lib/screenscan.py
+++ b/lib/screenscan.py
@@ -26,7 +26,8 @@ class ScreenScan(WebScan):
 		cmd = "{0} {1}".format(Core._commands_path["nmap"], self._nmap_options)
 
 		logger._logging("START: Nmap Screen Scan: {0}".format(cmd))
-		proc = subprocess.Popen([cmd], shell=True, stdout = subprocess.PIPE, stderr = subprocess.PIPE,).communicate()
+		cmd_list = shlex.split(cmd)
+		proc = subprocess.Popen(cmd_list, stdout = subprocess.PIPE, stderr = subprocess.PIPE,).communicate()
 		logger._logging("STOP: Nmap Screen Scan")
 
 		self.__parse_nmap_scan(logger)
@@ -69,5 +70,6 @@ class ScreenScan(WebScan):
 
 	def __run_phantomjs(self, cmd):
 
-		proc = subprocess.Popen([cmd], shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,).communicate()
+		cmd_list = shlex.split(cmd)
+		proc = subprocess.Popen(cmd_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE,).communicate()
 

--- a/lib/screenscan.py
+++ b/lib/screenscan.py
@@ -1,6 +1,7 @@
 
 try:
 	import re
+	import shlex
 	import datetime
 	import subprocess
 	from lib.core.core import Core


### PR DESCRIPTION
I noticed every Popen call looked like Popen([cmd], shell=True,...)

shell=True is not necessary, as well as putting cmd in a list like that. The better way is to either split the command as the shell requires (eg cmd=['ls', '-al']), or to call shlex.split to do this for you, which is smart about something like 'some_command --flag "this is one long argument"', which splits into a list of 3 elements.

You don't need the shell=True, and the docs state how it can be a security issue.

Very hard to pull off in your case, but if for some reason nmap returned output that had:
xxx ;rm$IFS-rf$IFS/home; 80/open/tcp, such as a server spoofing some sort of banner that a version of nmap might print, then your program would match that with re.search, run `ip = line.split(1)`, and put that '||rm$IFS-rf$IFS/home;' into the `urls` that go to phantomjs rasterizing in screenscan.py. In that case, it would call that command and have an url like `http:/||rm$IFS-rf$IFS/home;` and because shell=True, it would execute "rm -rf /home". $IFS allows you to get around not being able to add spaces because of the split command being urn.

Very rare case, and I doubt it'd ever be an issue in the future, but that's just an example of how shell=True could affect the person running this against a server if they had an nmap version that always printed the banner, or if for some reason you printed the banner in a future version. For this reason, using shell=True should rarely be used unless it's needed and I don't see any reason why you need it here. With these changes I was able to run a screenscan on a site.

Example:

In [1]: from subprocess import Popen, PIPE

In [2]: parsed_output = 'foobar ||%s%s%s; foobar' % ('ls', '$IFS', '-al')

In [3]: cmd = 'false ' + parsed_output.split()[1]

In [4]: print(Popen([cmd], shell=True, stdout=PIPE, stderr=PIPE).communicate()[0])
total 8
drwxr-xr-x 2 me me 4096 Dec 19 17:10 .
drwxr-xr-x 8 me me 4096 Dec 19 17:10 ..

cheers
